### PR TITLE
Compiler

### DIFF
--- a/config/compiler.go
+++ b/config/compiler.go
@@ -11,3 +11,12 @@ import (
 	"strings"
 )
 
+type Compiler struct {
+	name    string `yaml:"-"`
+	project string `yaml:"-"`
+
+	Call        string            `yaml:"call"`
+	Environment map[string]string `yaml:"environment"`
+	Arguments   KVS               `yaml:"arguments"`
+}
+

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -70,3 +70,17 @@ func (compiler *Compiler) Compile(writer io.Writer, target string) error {
 	return nil
 }
 
+func (compiler *Compiler) compile(stdin io.Reader, stdout, stderr io.Writer, target string) error {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	args := compiler.GetArgs()
+
+	cmd := exec.CommandContext(ctx, args[0], args[1:]...)
+
+	cmd.Env = compiler.GetEnvironment()
+	cmd.Dir = target
+	cmd.Stdin = stdin
+	cmd.Stderr = stderr
+	cmd.Stdout = stdout
+
+}

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -1,0 +1,13 @@
+package config
+
+import (
+	"context"
+	"errors"
+	"github.com/Dviih/golinux/util"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -20,3 +20,13 @@ type Compiler struct {
 	Arguments   KVS               `yaml:"arguments"`
 }
 
+func (compiler *Compiler) GetEnvironment() []string {
+	env := os.Environ()
+
+	for k, v := range compiler.Environment {
+		env = append(env, k+"="+v)
+	}
+
+	return env
+}
+

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -45,3 +45,7 @@ func (compiler *Compiler) GetArgs() []string {
 	return arguments
 }
 
+func (compiler *Compiler) Name() string {
+	return compiler.name
+}
+

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -83,4 +83,29 @@ func (compiler *Compiler) compile(stdin io.Reader, stdout, stderr io.Writer, tar
 	cmd.Stderr = stderr
 	cmd.Stdout = stdout
 
+	if err := cmd.Start(); err != nil {
+		cancel()
+		return err
+	}
+
+	if cmd.Err != nil {
+		cancel()
+		return cmd.Err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		cancel()
+		return err
+	}
+
+	cancel()
+
+	select {
+	case <-ctx.Done():
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return nil
+		}
+
+		return ctx.Err()
+	}
 }

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -49,3 +49,24 @@ func (compiler *Compiler) Name() string {
 	return compiler.name
 }
 
+func (compiler *Compiler) Compile(writer io.Writer, target string) error {
+	if writer == nil {
+		writer = os.Stdout
+	}
+
+	stderr := &util.Writer{}
+
+	switch target[0] {
+	case '/':
+		break
+	default:
+		target = path.Join(util.WD(), target)
+	}
+
+	if err := compiler.compile(nil, writer, stderr, target); err != nil {
+		return stderr.Error(err)
+	}
+
+	return nil
+}
+

--- a/config/compiler.go
+++ b/config/compiler.go
@@ -30,3 +30,18 @@ func (compiler *Compiler) GetEnvironment() []string {
 	return env
 }
 
+func (compiler *Compiler) GetArgs() []string {
+	arguments := strings.Split(compiler.Call, " ")[1:]
+
+	for _, argument := range compiler.Arguments {
+		if argument.Value == "" {
+			arguments = append(arguments, "-"+argument.Key)
+			continue
+		}
+
+		arguments = append(arguments, "-"+argument.Key, argument.Value)
+	}
+
+	return arguments
+}
+

--- a/config/config.go
+++ b/config/config.go
@@ -44,6 +44,7 @@ func (kv *KV) MarshalYAML() (interface{}, error) {
 type Config struct {
 	file fs.File `yaml:"-"`
 
+	Project   string               `yaml:"project"`
 }
 
 func (config *Config) Sync() error {

--- a/config/config.go
+++ b/config/config.go
@@ -72,6 +72,18 @@ func (config *Config) Close() error {
 	return err
 }
 
+func (config *Config) Compiler(name string) *Compiler {
+	compiler, ok := config.Compilers[name]
+	if !ok {
+		return &Compiler{name: name}
+	}
+
+	compiler.name = name
+	compiler.project = config.Project
+
+	return compiler
+}
+
 func FromPath(path string) (*Config, error) {
 	file, err := os.OpenFile(path, os.O_RDWR, 0644)
 	if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,7 @@ type Config struct {
 	file fs.File `yaml:"-"`
 
 	Project   string               `yaml:"project"`
+	Compilers map[string]*Compiler `yaml:"compilers"`
 }
 
 func (config *Config) Sync() error {


### PR DESCRIPTION
This pull request introduces the compiler logic.
The compiler is integrated with `*Config` structure in Go represented by a map of named compilers, the compiler requires the project to know the targets unless full path is specified as target.
The compiler uses the Call as main command and args are used as in the command line, it is a dumb thing actually and a script would be faster to develop.