### PR TITLE
Config Kernel auto .config setup

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,7 +94,7 @@ func (config *Config) Kernel(name string) *Kernel {
 
 	kernel.name = name
 	kernel.compiler = config.Compiler(kernel.Compiler)
-	kernel.Path = util.WDKernel(config.Project)
+	kernel.Path = util.WDKernel(config.Project, kernel.Name())
 
 	return kernel
 }

--- a/config/kernel.go
+++ b/config/kernel.go
@@ -65,5 +65,9 @@ func (kernel *Kernel) config(ctx context.Context) error {
 }
 
 func (kernel *Kernel) Build(ctx context.Context, writer io.Writer) error {
+	if err := kernel.config(ctx); err != nil {
+		return err
+	}
+
 	return kernel.compiler.Compile(ctx, writer, kernel.Path)
 }

--- a/config/kernel.go
+++ b/config/kernel.go
@@ -1,11 +1,11 @@
 package config
 
 import (
-	"bytes"
 	"context"
+	"github.com/Dviih/golinux/util"
 	"io"
 	"os"
-	"path"
+	"os/exec"
 )
 
 type Kernel struct {

--- a/config/kernel.go
+++ b/config/kernel.go
@@ -37,6 +37,10 @@ func (kernel *Kernel) Menu(ctx context.Context) error {
 	return nil
 }
 
+var configMap = map[string]string{
+	"CONFIG_DEFAULT_HOSTNAME": "golinux",
+}
+
 func (kernel *Kernel) Build(ctx context.Context, writer io.Writer) error {
 	return kernel.compiler.Compile(ctx, writer, kernel.Path)
 }

--- a/config/kernel.go
+++ b/config/kernel.go
@@ -41,6 +41,29 @@ var configMap = map[string]string{
 	"CONFIG_DEFAULT_HOSTNAME": "golinux",
 }
 
+func (kernel *Kernel) config(ctx context.Context) error {
+	configMap := configMap
+	configMap["CONFIG_INITRAMFS_SOURCE"] = util.WDInitramfs(kernel.compiler.project)
+
+	for property, value := range configMap {
+		var cmd *exec.Cmd
+
+		if value == "" {
+			cmd = exec.CommandContext(ctx, "./scripts/config", "--enable", property)
+		} else {
+			cmd = exec.CommandContext(ctx, "./scripts/config", "--set-str", property, value)
+		}
+
+		cmd.Dir = util.WDKernel(kernel.compiler.project, kernel.Name())
+
+		if err := cmd.Run(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func (kernel *Kernel) Build(ctx context.Context, writer io.Writer) error {
 	return kernel.compiler.Compile(ctx, writer, kernel.Path)
 }


### PR DESCRIPTION
This pull request adds a `config` method for Kernel that updates .config for initramfs making golinux runnable.